### PR TITLE
eat: Tambahkan ubin info tambahan ke halaman detail

### DIFF
--- a/lib/features/common/widgets/detailinfo_page.dart
+++ b/lib/features/common/widgets/detailinfo_page.dart
@@ -3,6 +3,7 @@ import 'package:afiyyah_connect/app/core/model/user.dart';
 import 'package:afiyyah_connect/app/themes/app_spacing.dart';
 import 'package:afiyyah_connect/features/common/utils/extension/extensions.dart';
 import 'package:afiyyah_connect/features/health_input/data/model/periksaklinikstatus_model.dart';
+import 'package:afiyyah_connect/features/monitoring/model/detailpageinfos_model.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
@@ -14,6 +15,7 @@ class DetailinfoPage extends StatelessWidget {
   final List<Widget> additionalTiles;
   final PeriksaKlinikStatus periksaKlinikStatus;
   final Role role;
+  final DetailPageInfosStyle detailPageInfosStyle;
 
   const DetailinfoPage({
     required this.santri,
@@ -23,6 +25,7 @@ class DetailinfoPage extends StatelessWidget {
     this.additionalTiles = const [],
     this.periksaKlinikStatus = PeriksaKlinikStatus.none,
     required this.role,
+    this.detailPageInfosStyle = DetailPageInfosStyle.standard,
     super.key,
   });
 

--- a/lib/features/common/widgets/patientlistcard_component.dart
+++ b/lib/features/common/widgets/patientlistcard_component.dart
@@ -13,6 +13,7 @@ class ListCardItem extends StatelessWidget {
   final String info;
   final Color? customNotchColor;
   final List<String> keluhan;
+  final List<Widget>? additionalTiles;
 
   const ListCardItem({
     required this.santri,
@@ -20,6 +21,7 @@ class ListCardItem extends StatelessWidget {
     this.customNotchColor,
     //TODO : use real keluhan
     this.keluhan = const ['demam', 'batuk', 'pilek'],
+    this.additionalTiles,
     super.key,
   });
 
@@ -44,7 +46,8 @@ class ListCardItem extends StatelessWidget {
             builder: (context) => DetailinfoPage(
               santri: santri,
               keluhan: keluhan,
-              // TODO : insert with real Role data
+              // TODO : insert with real Role data,
+              additionalTiles: additionalTiles ?? [],
               role: Role.resepsionisKlinik,
               sickTime: DateTime(2020),
             ),

--- a/lib/features/monitoring/model/detailpageinfos_model.dart
+++ b/lib/features/monitoring/model/detailpageinfos_model.dart
@@ -1,0 +1,1 @@
+enum DetailPageInfosStyle { standard, arahan, rujukan }

--- a/lib/features/monitoring/view/tabviewmonitoring.dart
+++ b/lib/features/monitoring/view/tabviewmonitoring.dart
@@ -100,6 +100,12 @@ class TabViewMonitoring extends StatelessWidget {
         ...List.generate(3, (index) {
           return ListCardItem(
             santri: Santri.generateDummyData(),
+            additionalTiles: [
+              ListTile(
+                title: Text('RS / Klinik Rujukan'),
+                leading: Icon(Icons.health_and_safety_rounded),
+              ),
+            ],
             info: 'Batuk, pilek, panas',
             customNotchColor: index < 2 ? colors[0] : colors[1],
           );


### PR DESCRIPTION
   2
   3 Perubahan ini menambahkan kemampuan untuk meneruskan daftar
     ubin (`additionalTiles`) dari `ListCardItem` ke
     `DetailinfoPage`.

   5 Hal ini memungkinkan halaman detail untuk menampilkan
     informasi tambahan yang relevan secara kontekstual, seperti
     ubin "RS / Klinik Rujukan" dari tab monitoring, sehingga
     membuat komponen `DetailinfoPage` lebih dapat digunakan
     kembali.